### PR TITLE
Add whoami routing path

### DIFF
--- a/packages/soya-next-scripts/scripts/start.js
+++ b/packages/soya-next-scripts/scripts/start.js
@@ -62,6 +62,7 @@ app.prepare()
       defaultLocale: config.defaultLocale,
       siteLocales: config.siteLocales,
       compression: config.server.compression,
+      whoami: config.whoami,
     }));
     server.listen(config.server.port, config.server.host, err => {
       if (err) {

--- a/packages/soya-next/src/router/__tests__/createRouter.test.js
+++ b/packages/soya-next/src/router/__tests__/createRouter.test.js
@@ -56,7 +56,7 @@ describe('createRouter', () => {
           path: '/react.png',
         },
       };
-      const res = {};
+      const res = { json: jest.fn() };
       const next = jest.fn();
 
       // redirects middleware
@@ -70,11 +70,11 @@ describe('createRouter', () => {
       expect(next.mock.calls.length).toBe(2);
 
       // next handler
-      await router.routes[0].handler(req, res);
+      await router.routes[1].handler(req, res);
       expect(app.handle).toBeCalled();
 
       expect(router.use.mock.calls.length).toBe(2);
-      expect(router.get.mock.calls.length).toBe(1);
+      expect(router.get.mock.calls.length).toBe(2);
       expect(app.getRequestHandler).toBeCalled();
     });
 
@@ -91,7 +91,7 @@ describe('createRouter', () => {
       }, {});
       expect(app.render).toBeCalled();
       expect(app.render.mock.calls[0]).toMatchSnapshot();
-      expect(router.get.mock.calls.length).toBe(2);
+      expect(router.get.mock.calls.length).toBe(3);
     });
 
     it('should create router with redirection', () => {
@@ -124,7 +124,7 @@ describe('createRouter', () => {
         params: { id: 1 },
       }, res);
       expect(res.redirect.mock.calls[1]).toMatchSnapshot();
-      expect(router.get.mock.calls.length).toBe(4);
+      expect(router.get.mock.calls.length).toBe(5);
     });
 
     it('should create locale aware router', () => {

--- a/packages/soya-next/src/router/__tests__/createRouter.test.js
+++ b/packages/soya-next/src/router/__tests__/createRouter.test.js
@@ -69,6 +69,10 @@ describe('createRouter', () => {
       expect(req).toHaveProperty('universalCookies');
       expect(next.mock.calls.length).toBe(2);
 
+      // whoami
+      router.routes[0].handler(req, res);
+      expect(res.json).toBeCalled();
+
       // next handler
       await router.routes[1].handler(req, res);
       expect(app.handle).toBeCalled();

--- a/packages/soya-next/src/router/createRouter.js
+++ b/packages/soya-next/src/router/createRouter.js
@@ -16,6 +16,7 @@ export default (app, {
   defaultLocale,
   siteLocales,
   compression,
+  whoami = {},
 } = defaultOptions) => {
   const router = Router();
   const handle = app.getRequestHandler();
@@ -51,6 +52,14 @@ export default (app, {
     const { method = 'GET', page } = routes[path];
     router[method.toLowerCase()](path, (req, res) => {
       app.render(req, res, page, Object.assign({}, req.query, req.params));
+    });
+  });
+  router.get('/whoami', (req, res) => {
+    const uptime = process.uptime();
+    res.json({
+      nodeId: process.env.NODE_GROUP,
+      uptime: `${Math.floor(uptime / 86400)}d, ${Math.floor((uptime % 86400) / 3600)}h, ${Math.floor((uptime % 3600) / 60)}m, ${Math.floor(uptime % 60)}s`,
+      ...whoami,
     });
   });
   router.get('*', (req, res) => handle(req, res));


### PR DESCRIPTION
The whoami routing path will help us to identify machine/process on which soya-next app is running. It can also be used to identify what version is being deployed.