### PR TITLE
[FIX] add bundle analyzer default config

### DIFF
--- a/packages/soya-next-scripts/plugins/index.js
+++ b/packages/soya-next-scripts/plugins/index.js
@@ -1,6 +1,6 @@
 const config = require("config");
 const withAssetsImport = require("next-assets-import");
-const withBundleAnalyzer = require("@zeit/next-bundle-analyzer");
+const withBundleAnalyzer = require("./withBundleAnalyzer");
 const withCSS = require("./withCSS");
 const withCSSModules = require("./withCSSModules");
 const withConfig = require("next-config");

--- a/packages/soya-next-scripts/plugins/withBundleAnalyzer.js
+++ b/packages/soya-next-scripts/plugins/withBundleAnalyzer.js
@@ -1,0 +1,28 @@
+const withBundleAnalyzer = require("@zeit/next-bundle-analyzer");
+
+module.exports = (nextConfig = {}) =>
+  Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      const { webpack } = withBundleAnalyzer({
+        analyzeServer: ["server", "both"].includes(process.env.BUNDLE_ANALYZE),
+        analyzeBrowser: ["browser", "both"].includes(process.env.BUNDLE_ANALYZE),
+        bundleAnalyzerConfig: {
+          server: {
+            analyzerMode: 'static',
+            reportFilename: '../../bundles/server.html'
+          },
+          browser: {
+            analyzerMode: 'static',
+            reportFilename: '../bundles/client.html'
+          }
+        }
+      });
+      const newConfig = webpack(config, options);
+
+      if (typeof nextConfig.webpack === "function") {
+        return nextConfig.webpack(newConfig, options);
+      }
+
+      return newConfig;
+    }
+  });


### PR DESCRIPTION
previously if `BUNDLE_ANALYZE=both yarn build` is executed it doesn't create analyzer report page because missing config
this pull request add the missing config