### PR TITLE
[Enhancement] Allow non js extension for custom _app and _document files.

### DIFF
--- a/packages/soya-next-scripts/plugins/withApp.js
+++ b/packages/soya-next-scripts/plugins/withApp.js
@@ -17,7 +17,8 @@ module.exports = (nextConfig = {}) =>
           name => name === join("static", options.buildId, "pages", "_app.js")
         );
         const [pageEntry] = entries[name];
-        if (normalize(pageEntry) !== join("pages", "_app.js")) {
+        const matchedEntryPattern = new RegExp(`^${join("pages", "_app")}\\.(js|jsx|ts|tsx)$`);
+        if (!matchedEntryPattern.test(normalize(pageEntry))) {
           entries[name] = [require.resolve(join("..", "pages", "_app"))];
         }
         return entries;

--- a/packages/soya-next-scripts/plugins/withDocument.js
+++ b/packages/soya-next-scripts/plugins/withDocument.js
@@ -19,7 +19,8 @@ module.exports = (nextConfig = {}) =>
               name === join("static", options.buildId, "pages", "_document.js")
           );
           const [pageEntry] = entries[name];
-          if (normalize(pageEntry) !== join("pages", "_document.js")) {
+          const matchedEntryPattern = new RegExp(`^${join("pages", "_document")}\\.(js|jsx|ts|tsx)$`);
+          if (!matchedEntryPattern.test(normalize(pageEntry))) {
             entries[name] = [require.resolve(join("..", "pages", "_document"))];
           }
           return entries;


### PR DESCRIPTION
**Details**:

Currently soya-next-scripts does not load custom `_app` and `_document` file if the extension is not `*.js`. This issue cause it will use the fallback files from `src/pages/_app.js` or `src/pages/_document.js`.

Test case with TypeScript:

1. Add `semantic-ui-react`, `semantic-ui-css`, `typescript`, and `@zeit/next-typescript`.
2. Configure `next.config.js` to accept typescript.
3. Create `_app.tsx` and `_document.tsx` inside `pages` directory. (Using [with-emotion](https://github.com/zeit/next.js/tree/canary/examples/with-emotion) example.)
4. Modify `index.tsx` page using semantic component.
5. Ensure that there is no FOUC when the content is rendered.



