### PR TITLE
Update `storeShape` to match `react-redux` PropTypes util.

### DIFF
--- a/packages/soya-next/src/pages/withReduxStore.js
+++ b/packages/soya-next/src/pages/withReduxStore.js
@@ -1,8 +1,8 @@
+import PropTypes from "prop-types";
 import React from "react";
 import hoistStatics from "hoist-non-react-statics";
 import { compose } from "redux";
 import { connect, Provider } from "react-redux";
-import { storeShape } from "react-redux/lib/utils/PropTypes";
 import applyReducers from "../redux/applyReducers";
 import withStore from "../redux/withStore";
 
@@ -14,7 +14,11 @@ export default configureStore => (reducers, ...connectArgs) => Page => {
 
   class WithReduxStore extends React.Component {
     static propTypes = {
-      store: storeShape.isRequired
+      store: PropTypes.shape({
+        subscribe: PropTypes.func.isRequired,
+        dispatch: PropTypes.func.isRequired,
+        getState: PropTypes.func.isRequired
+      }).isRequired
     };
 
     render() {

--- a/packages/soya-next/src/redux/applyReducers.js
+++ b/packages/soya-next/src/redux/applyReducers.js
@@ -1,6 +1,6 @@
+import PropTypes from "prop-types";
 import React from "react";
 import hoistStatics from "hoist-non-react-statics";
-import { storeShape } from "react-redux/lib/utils/PropTypes";
 import getDisplayName from "../utils/getDisplayName";
 import { NEXT_STATICS } from "../constants/Statics";
 
@@ -25,7 +25,11 @@ export default reducers => Component => {
     }
 
     static contextTypes = {
-      store: storeShape.isRequired
+      store: PropTypes.shape({
+        subscribe: PropTypes.func.isRequired,
+        dispatch: PropTypes.func.isRequired,
+        getState: PropTypes.func.isRequired
+      }).isRequired
     };
 
     constructor(props, context) {

--- a/packages/soya-next/src/redux/withStore.js
+++ b/packages/soya-next/src/redux/withStore.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import hoistStatics from "hoist-non-react-statics";
-import { storeShape } from "react-redux/lib/utils/PropTypes";
 import getDisplayName from "../utils/getDisplayName";
 import { NEXT_STATICS } from "../constants/Statics";
 
@@ -21,7 +20,14 @@ export default configureStore => Page => {
 
     static propTypes = {
       reduxState: PropTypes.object.isRequired,
-      store: PropTypes.oneOfType([PropTypes.object, storeShape]).isRequired
+      store: PropTypes.oneOfType([
+          PropTypes.object,
+          PropTypes.shape({
+            subscribe: PropTypes.func.isRequired,
+            dispatch: PropTypes.func.isRequired,
+            getState: PropTypes.func.isRequired
+          })
+        ]).isRequired
     };
 
     static async getInitialProps(ctx) {


### PR DESCRIPTION
**Descriptions**
As titled.

**Background**
Got an error while trying to execute `soya-next-scripts dev`:
```
yarn run v1.15.2
warning package.json: No license field
$ soya-next-scripts dev
[ error ] ./node_modules/soya-next/lib/pages/withReduxStore.js
Module not found: Can't resolve 'react-redux/lib/utils/PropTypes' in '/home/imam/payment-web/payod-web/node_modules/soya-next/lib/pages'
> Ready on 0.0.0.0:51008
```

After quick checking, `PropTypes.js` utility file does not exist anymore inside the latest `react-redux` repository, so I update the definition of required `storeShape` definition from this file (using 5.x branch): https://github.com/reduxjs/react-redux/blob/5.x/src/utils/PropTypes.js