### PR TITLE
fix: bump cli script to install 0.8.4 packages

### DIFF
--- a/packages/soya-next-cli/src/index.js
+++ b/packages/soya-next-cli/src/index.js
@@ -39,11 +39,11 @@ const dependencies = [
   "react-dom@16.8.6",
   "react-redux@5.0.7",
   "redux@4.0.0",
-  "soya-next@0.8.0",
-  "soya-next-server@0.8.0"
+  "soya-next@0.8.4",
+  "soya-next-server@0.8.4"
 ];
 
-const devDependencies = ["soya-next-scripts@0.8.0"];
+const devDependencies = ["soya-next-scripts@0.8.4"];
 
 const install = (cmd, dependencies, { dev = false, exact = true } = {}) => {
   const args = [];


### PR DESCRIPTION
## Description

Bump cli dependencies to in install script to get the latest version. 

## Related issue

https://github.com/traveloka/soya-next/issues/242

## How was this tested

`npm link` and running `soya-next-cli`